### PR TITLE
Change default prefix to /usr/sbin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PREFIX := /usr/bin
+PREFIX := /usr/sbin
 
 all:
 	@echo "Nothing to build"


### PR DESCRIPTION
To better follow convention, change the default prefix of a binary that requires root to /usr/sbin

Source 1: http://www.tldp.org/LDP/Linux-Filesystem-Hierarchy/html/sbin.html
Source 2: http://askubuntu.com/questions/308045/differences-between-bin-sbin-usr-bin-usr-sbin-usr-local-bin-usr-local
